### PR TITLE
Upgrade command / Windows static binary

### DIFF
--- a/cmd/wapc/main.go
+++ b/cmd/wapc/main.go
@@ -13,6 +13,8 @@ var cli struct {
 	Generate commands.GenerateCmd `cmd:"" help:"Generate code from a configuration file."`
 	// New creates a new project from a template.
 	New commands.NewCmd `cmd:"" help:"Creates a new project from a template."`
+	// Upgrade reinstalls the base module dependencies.
+	Upgrade commands.UpgradeCmd `cmd:"" help:"Upgrades to the latest base modules dependencies."`
 }
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -16,5 +16,5 @@ require (
 	golang.org/x/term v0.0.0-20210317153231-de623e64d2a6 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
-	rogchap.com/v8go v0.5.1
+	rogchap.com/v8go v0.5.2-0.20210423120543-491864424893
 )

--- a/go.sum
+++ b/go.sum
@@ -54,5 +54,5 @@ gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EV
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-rogchap.com/v8go v0.5.1 h1:yx7uQC2ezAHthCHLHl4NuH3eprVLBtNl6Utm/ELjZ+w=
-rogchap.com/v8go v0.5.1/go.mod h1:IitZnaOtWSJadY/7qinKHIEHpxsilMWyLQ+Efdo4n4I=
+rogchap.com/v8go v0.5.2-0.20210423120543-491864424893 h1:4yu8bXxoh1FkLSp21WRMieH+0xmlkFAczeEUibvQZFQ=
+rogchap.com/v8go v0.5.2-0.20210423120543-491864424893/go.mod h1:IitZnaOtWSJadY/7qinKHIEHpxsilMWyLQ+Efdo4n4I=

--- a/pkg/commands/upgrade.go
+++ b/pkg/commands/upgrade.go
@@ -1,0 +1,13 @@
+package commands
+
+type UpgradeCmd struct {
+}
+
+func (c *UpgradeCmd) Run(ctx *Context) error {
+	wapcHome, err := ensureHomeDirectory()
+	if err != nil {
+		return err
+	}
+
+	return checkDependencies(wapcHome, true)
+}


### PR DESCRIPTION
Added the upgrade command to force reinstall/upgrade the CLI's base module dependencies.
Using master branch of v8go to get static windows binary support until the next release.