### PR TITLE
WIDL imports and developer experience enhancements

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,5 +16,5 @@ require (
 	golang.org/x/term v0.0.0-20210317153231-de623e64d2a6 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
-	rogchap.com/v8go v0.5.2-0.20210423120543-491864424893
+	rogchap.com/v8go v0.6.0
 )

--- a/go.sum
+++ b/go.sum
@@ -54,5 +54,5 @@ gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EV
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-rogchap.com/v8go v0.5.2-0.20210423120543-491864424893 h1:4yu8bXxoh1FkLSp21WRMieH+0xmlkFAczeEUibvQZFQ=
-rogchap.com/v8go v0.5.2-0.20210423120543-491864424893/go.mod h1:IitZnaOtWSJadY/7qinKHIEHpxsilMWyLQ+Efdo4n4I=
+rogchap.com/v8go v0.6.0 h1:wNn5Iu06+ke7HM511zXTVBBpRNYaauyZoPMTrLsGurU=
+rogchap.com/v8go v0.6.0/go.mod h1:IitZnaOtWSJadY/7qinKHIEHpxsilMWyLQ+Efdo4n4I=

--- a/pkg/commands/generate.go
+++ b/pkg/commands/generate.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/evanw/esbuild/pkg/api"
 	"gopkg.in/yaml.v3"
+	"rogchap.com/v8go"
 
 	"github.com/wapc/cli/pkg/js"
 )
@@ -28,8 +29,9 @@ type GenerateCmd struct {
 }
 
 type Config struct {
-	Schema    string            `json:"schema" yaml:"schema"`
-	Generates map[string]Target `json:"generates" yaml:"generates"`
+	Schema    string                 `json:"schema" yaml:"schema"`
+	Config    map[string]interface{} `json:"config,omitempty" yaml:"config,omitempty"`
+	Generates map[string]Target      `json:"generates" yaml:"generates"`
 }
 
 type Target struct {
@@ -43,15 +45,22 @@ const generateTemplate = `import { parse } from "@wapc/widl";
 import { Context, Writer } from "@wapc/widl/ast";
 import { {{visitorClass}} } from "{{module}}";
 
+function resolver(location, from) {
+  const source = resolverCallback(location, from);
+  if (source.startsWith("error: ")) {
+    throw source.substring(7);
+  }
+  return source;
+}
+
 export function generate(widl, config) {
-  const doc = parse(widl);
+  const doc = parse(widl, resolver);
   const context = new Context(config);
 
   const writer = new Writer();
   const visitor = new {{visitorClass}}(writer);
   doc.accept(context, visitor);
   let source = writer.string();
-  console.log(source);
 
   return source;
 }
@@ -109,6 +118,17 @@ func (c *GenerateCmd) generate(configYAML string) error {
 				continue
 			}
 		}
+
+		// Merge global config into target config
+		if target.Config == nil && config.Config != nil {
+			target.Config = make(map[string]interface{}, len(config.Config))
+		}
+		for k, v := range config.Config {
+			if _, exists := target.Config[k]; !exists {
+				target.Config[k] = v
+			}
+		}
+
 		fmt.Printf("Generating %s...\n", filename)
 		generateTS := generateTemplate
 		generateTS = strings.Replace(generateTS, "{{module}}", target.Module, 1)
@@ -133,7 +153,57 @@ func (c *GenerateCmd) generate(configYAML string) error {
 
 		bundle := string(result.OutputFiles[0].Contents)
 
-		j, err := js.Compile(bundle)
+		definitionsDir := filepath.Join(homeDir, "definitions")
+
+		resolverCallback := func(info *v8go.FunctionCallbackInfo) *v8go.Value {
+			iso, err := info.Context().Isolate()
+			if err != nil {
+				return nil
+			}
+
+			if len(info.Args()) < 1 {
+				value, _ := v8go.NewValue(iso, "error: resolve: invalid arguments")
+				return value
+			}
+
+			location := info.Args()[0].String()
+
+			loc := filepath.Join(definitionsDir, filepath.Join(strings.Split(location, "/")...))
+			if filepath.Ext(loc) != ".widl" {
+				widlLoc := loc + ".widl"
+				found := false
+				stat, err := os.Stat(widlLoc)
+				if err == nil {
+					found = !stat.IsDir()
+				}
+
+				if !found {
+					stat, err := os.Stat(loc)
+					if err != nil {
+						value, _ := v8go.NewValue(iso, fmt.Sprintf("error: %v", err))
+						return value
+					}
+					if stat.IsDir() {
+						loc = filepath.Join(loc, "index.widl")
+					} else {
+						loc += ".widl"
+					}
+				}
+			}
+
+			data, err := os.ReadFile(loc)
+			if err != nil {
+				value, _ := v8go.NewValue(iso, fmt.Sprintf("error: %v", err))
+				return value
+			}
+
+			value, _ := v8go.NewValue(iso, string(data))
+			return value
+		}
+
+		j, err := js.Compile(bundle, map[string]v8go.FunctionCallback{
+			"resolverCallback": resolverCallback,
+		})
 		if err != nil {
 			return err
 		}
@@ -144,6 +214,9 @@ func (c *GenerateCmd) generate(configYAML string) error {
 		}
 		res, err := j.Invoke("generate", schema, target.Config)
 		if err != nil {
+			if jserr, ok := err.(*v8go.JSError); ok {
+				jserr.Message = strings.TrimPrefix(jserr.Message, "Error: ")
+			}
 			return err
 		}
 

--- a/pkg/commands/home.go
+++ b/pkg/commands/home.go
@@ -29,6 +29,19 @@ func getHomeDirectory() (string, error) {
 	return wapcHome, err
 }
 
+const tsconfigContents = `{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "esnext",
+    "baseUrl": ".",
+    "lib": [      
+      "esnext"
+    ],
+    "outDir": "../dist"
+  }
+}
+`
+
 func ensureHomeDirectory() (string, error) {
 	home, err := homedir.Dir()
 	if err != nil {
@@ -42,6 +55,7 @@ func ensureHomeDirectory() (string, error) {
 	wapcHome := filepath.Join(home, ".wapc")
 	srcDir := filepath.Join(wapcHome, "src")
 	templatesDir := filepath.Join(wapcHome, "templates")
+	definitionsDir := filepath.Join(wapcHome, "definitions")
 
 	if _, err := os.Stat(srcDir); os.IsNotExist(err) {
 		if err = os.MkdirAll(srcDir, 0700); err != nil {
@@ -49,8 +63,22 @@ func ensureHomeDirectory() (string, error) {
 		}
 	}
 
+	// Create tsconfig.json inside the src directory for editing inside an IDE.
+	tsconfigJSON := filepath.Join(srcDir, "tsconfig.json")
+	if _, err := os.Stat(tsconfigJSON); os.IsNotExist(err) {
+		if err = os.WriteFile(tsconfigJSON, []byte(tsconfigContents), 0644); err != nil {
+			return "", err
+		}
+	}
+
 	if _, err := os.Stat(templatesDir); os.IsNotExist(err) {
 		if err = os.MkdirAll(templatesDir, 0700); err != nil {
+			return "", err
+		}
+	}
+
+	if _, err := os.Stat(definitionsDir); os.IsNotExist(err) {
+		if err = os.MkdirAll(definitionsDir, 0700); err != nil {
 			return "", err
 		}
 	}


### PR DESCRIPTION
- Resolve WIDL imports from ~/.wapc/definitions
- Install from directory for local development (ex. `wapc install file:.` installs the current working directory)
- Global `config` settings that merge into to each "generates" config
- Create tsconfig.json in ~/.wapc/src if not present so there are no compiler errors in VS Code
- Implemented console.log for debugging code generation