### PR TITLE
Add environment variable for npm registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ brew install wapc/tap/wapc
 
 #### Create a waPC module
 
-###### Note for users not using the standard NPM Registry
+##### Note for users not using the standard NPM Registry
 
 Set an environment variable called `NPM_REG` to set the registry host for the cli
 ```

--- a/README.md
+++ b/README.md
@@ -59,13 +59,6 @@ brew install wapc/tap/wapc
 
 #### Create a waPC module
 
-##### Note for users not using the standard NPM Registry
-
-Set an environment variable called `NPM_REG` to set the registry host for the cli
-```
-NPM_REG="https://my.reg.com/npm" wapc new ...
-```
-
 AssemblyScript
 
 ```shell
@@ -93,6 +86,13 @@ make build
 ```
 
 The `build` directory will contain your `.wasm` file.
+
+##### Note for users not using the standard NPM Registry
+
+Set an environment variable called `NPM_REG` to set the registry host for the cli
+```
+NPM_REG="https://my.reg.com/npm" wapc new ...
+```
 
 ### Basic Scaffolding
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,13 @@ brew install wapc/tap/wapc
 
 #### Create a waPC module
 
+###### Note for users not using the standard NPM Registry
+
+Set an environment variable called `NPM_REG` to set the registry host for the cli
+```
+NPM_REG="https://my.reg.com/npm" wapc new ...
+```
+
 AssemblyScript
 
 ```shell

--- a/pkg/commands/install.go
+++ b/pkg/commands/install.go
@@ -194,7 +194,11 @@ func (c *InstallCmd) getReleaseInfoFromNPM(location, releaseTag string) (*releas
 		releaseTag = "latest"
 	}
 
-	npmURL := fmt.Sprintf("https://registry.npmjs.org/%s/%s/", location, releaseTag)
+        npmHost, present := os.LookupEnv("NPM_REG")
+        if !present {
+          npmHost = "https://registry.npmjs.org"
+        }
+	npmURL := fmt.Sprintf("%s/%s/%s/", npmHost, location, releaseTag)
 	resp, err := c.netClient.Get(npmURL)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This PR simply adds a check that, if present, uses an environment variable for the NPM Registry. This makes the cli more adaptable especially when running behind a corporate firewall. In reference to #11 